### PR TITLE
Configure travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: minimal
+
+services:
+  - docker
+
+jobs:
+  include:
+    - stage: packaging tests
+      name: "Docker"
+      before_install:
+        - docker pull radiorabe/suisa_sendemeldung
+      script: docker build -t suisa_sendemeldung --cache-from radiorabe/suisa_sendemeldung .
+    - stage: packaging tests
+      name: "RPM"
+      before_install:
+        - docker pull quay.io/hairmare/centos_rpmdev
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/centos_rpmdev /git/.travis/rpm.sh

--- a/.travis/rpm.sh
+++ b/.travis/rpm.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# RPM build wrapper for suisa_sendemeldung, runs inside the build container on travis-ci
+
+set -xe
+
+curl -o /etc/yum.repos.d/sendemeldung.repo https://download.opensuse.org/repositories/home:/radiorabe:/sendemeldung/CentOS_7/home:radiorabe:sendemeldung.repo
+
+chown root:root suisa_sendemeldung.spec
+
+create-source-tarball.sh /git suisa_sendemeldung-master.tar.gz
+
+build-rpm-package.sh suisa_sendemeldung.spec


### PR DESCRIPTION
This is a very simple travis-ci config that just adds build testing for the docker and rpm deliverables.

I hacked this together after giving renovate access to make it's onboarding pr and then realizing that we should have at least some safeguards in place when we merge renovate prs.

@am5z Have you considered how you we want to test the python code long term? This just focuses on the build parts but could easily get extended to also cover the python code. 

I also built [these](https://hub.docker.com/r/radiorabe/suisa_sendemeldung/) to act as a build cache, but that's just me over engineering things.