### PR TITLE
Revert "fix build"

### DIFF
--- a/.travis/rpm.sh
+++ b/.travis/rpm.sh
@@ -10,5 +10,4 @@ chown root:root suisa_sendemeldung.spec
 
 create-source-tarball.sh /git suisa_sendemeldung-master.tar.gz
 
-yum -y install python3-devel
 build-rpm-package.sh suisa_sendemeldung.spec


### PR DESCRIPTION
Reverts radiorabe/suisa_sendemeldung#27

It would be better to add python3-devel to BuildRequires in the specfile