### PR TITLE
add python3-devel to BuildRequires

### DIFF
--- a/suisa_sendemeldung.spec
+++ b/suisa_sendemeldung.spec
@@ -43,6 +43,7 @@ BuildRequires:  python%{python3_pkgversion}-configargparse
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-requests
+BuildRequires:  python3-devel
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils


### PR DESCRIPTION
The build failed because the rpm macros %py3_* are provided by a dependency of python3-devel