### PR TITLE
chore(container image): migrate to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+name: Build Container Image
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/radiorabe/suisasendemeldung
+          tag-sha: false
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_PAT_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Or by setting environment variables:
 sudo docker run --rm --env ACCESS_KEY=abcdefghijklmnopqrstuvwxyzabcdef --env STREAM_ID=a-bcdefgh --env STDOUT=True suisa_sendemeldung
 ```
 
+A prebuilt image is available from the GitHub Package Registry:
+
+```bash
+docker pull ghcr.io/radiorabe/suisasendemeldung:master
+```
+
 ## Usage
 
 This is the output of `suisa_sendemeldung -h`.


### PR DESCRIPTION
Our container environment is already having issues with the newly introduced [download rate limit](https://docs.docker.com/docker-hub/download-rate-limit/) so I am migrating all our images to the GitHub Container Registry.

I've already prepared the secret needed to logon to the registry so this will build and push images on `master` after we merge it.