### PR TITLE
chore(ci): replace crazy-max/ghaction-docker-meta with docker/metadata-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,12 +21,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+      - name: Prepare Image Metadata
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/radiorabe/suisasendemeldung
-          tag-sha: false
+          images: |
+            ghcr.io/radiorabe/suisasendemeldung
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -43,5 +51,5 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Replaces `crazy-max/ghaction-docker-meta` with it's new replacement `docker/metadata-action`.

It's the same action but it got adopted by the folks managing the `docker` orga on GitHub.

Fixes #71 

