### PR TITLE
fix: timeout acr requests after 10 seconds

### DIFF
--- a/suisa_sendemeldung/acrclient.py
+++ b/suisa_sendemeldung/acrclient.py
@@ -38,7 +38,7 @@ class ACRClient:
             access_key=self.access_key, date=requested_date.strftime("%Y%m%d")
         )
         url = f"https://api.acrcloud.com/v1/monitor-streams/{stream_id}/results"
-        response = requests.get(url=url, params=url_params)
+        response = requests.get(url=url, params=url_params, timeout=10)
         response.raise_for_status()
 
         data = response.json()


### PR DESCRIPTION
This should basically never happen unless somthing is bad between us and acr cloud.