### PR TITLE
chore: cd pipeline with semantic release and publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Build Container Image
+name: Release
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  container:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,7 +36,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -44,7 +43,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_PAT_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
@@ -56,3 +55,30 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  wheel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - run: python -m pip install --upgrade pip
+
+      - run: pip install -r requirements-dev.txt
+
+      - name: Build Wheel
+        run: python setup.py sdist bdist_wheel
+
+      - name: Run twine
+        if: github.event_name != 'pull_request'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.RABE_PYPI_TOKEN }}
+          TWINE_NON_INTERACTIVE: true
+        run: twine upload dist/*

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,4 +1,4 @@
-name: Run semantic-release
+name: Semantic Release
 
 on:
   push:
@@ -6,17 +6,7 @@ on:
       - main
 
 jobs:
-  semantic-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Run go-semantic-release
-        id: semrel
-        uses: go-semantic-release/action@v1
-        with:
-          github-token: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}
-          allow-initial-development-versions: true
+  call-workflow:
+    uses: radiorabe/actions/.github/workflows/semantic-release.yaml@main
+    secrets:
+      RABE_ITREAKTION_GITHUB_TOKEN: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,0 +1,22 @@
+name: Run semantic-release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run go-semantic-release
+        id: semrel
+        uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}
+          allow-initial-development-versions: true

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   call-workflow:
-    uses: radiorabe/actions/.github/workflows/semantic-release.yaml@main
+    uses: radiorabe/actions/.github/workflows/semantic-release.yaml@v0.7.0
     secrets:
       RABE_ITREAKTION_GITHUB_TOKEN: ${{ secrets.RABE_ITREAKTION_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -108,3 +108,35 @@ As documented in [Usage](#Usage), you can also pass in options on the command li
 ```bash
 ./suisa_sendemeldung.py --access_key=abcdefghijklmnopqrstuvwxyzabcdef --stream_id=a-bcdefgh --stdout
 ```
+
+## Release Management
+
+The CI/CD setup uses semantic commit messages following the [conventional commits standard](https://www.conventionalcommits.org/en/v1.0.0/).
+There is a GitHub Action in [.github/workflows/semantic-release.yaml](./.github/workflows/semantic-release.yaml)
+that uses [go-semantic-commit](https://go-semantic-release.xyz/) to create new
+releases.
+
+The commit message should be structured as follows:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The commit contains the following structural elements, to communicate intent to the consumers of your library:
+
+1. **fix:** a commit of the type `fix` patches gets released with a PATCH version bump
+1. **feat:** a commit of the type `feat` gets released as a MINOR version bump
+1. **BREAKING CHANGE:** a commit that has a footer `BREAKING CHANGE:` gets released as a MAJOR version bump
+1. types other than `fix:` and `feat:` are allowed and don't trigger a release
+
+If a commit does not contain a conventional commit style message you can fix
+it during the squash and merge operation on the PR.
+
+Once a commit has landed on the `main` branch a release will be created and automatically published to [pypi](https://pypi.org/)
+using the GitHub Action in [.github/workflows/release.yaml](./.github/workflows/reliease.yaml) which uses [twine](https://twine.readthedocs.io/)
+to publish the package to pypi. The `release.yaml` action also takes care of pushing a [container](https://opencontainers.org/)
+image to [GitHub Packages](https://github.com/features/packages).


### PR DESCRIPTION
This automates tagging new versions and starts publishing versioned artifacts. I'm also adding pypi as a deployment target (because we can). I already prepped the needed secrets in the @radiorabe orga. If all goes well then merging this will cause a `v0.4.0` tag to be created and published.