### PR TITLE
feat: add CRID as Identifikationsnummer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ConfigArgParse==1.5.3
 pytz==2022.7
 requests==2.28.1
+rabe-cridlib==0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ description-file = README.md
 
 [tool:pytest]
 addopts = --doctest-modules --cov=suisa_sendemeldung --pylint --cov-fail-under=100
+filterwarnings =
+    ignore::DeprecationWarning:pylint
+    ignore::pytest.PytestRemovedIn8Warning:pytest_pylint


### PR DESCRIPTION
This adds an "Identifikationsnummer" field that is both required and very loosely defined in [Gemeinsamer Tarif S](https://www.suisa.ch/dam/jcr:1d82128b-8cc7-4cf0-b0ef-1890ae9d434d/GTS_2020-2023_GER.pdf).

The ID we use is based on [crid-spec](https://github.com/radiorabe/crid-spec) (RABE-CRID) but it adds the `acrid` from ACR Cloud to the media fragment part of the URLs. The actual implementation is based on [rabe-cridlib](https://github.com/radiorabe/python-rabe-cridlib) which, under the hood, calls our archive to generate the `show` part of a RABE-CRID.

Here are some examples of what it generates for Nov 2022:

```csv
Sendedatum,Sendezeit,Sendedauer,Titel,Künstler,Komponist,ISRC,Label,Identifikationsnummer
29/11/22,00:01:02,0:02:40,Ten Feet Tall,Fat Freddys Drop,Fat Freddys Drop,QM6N21943200,ORCHARD - Best's Friends,crid://rabe.ch/v1/klangbecken#t=clock=20221129T000102.00Z&acrid=f6d7453d72bdb69f741b9e2d4721d727
29/11/22,00:03:47,0:01:33,Judged,Billy Talent,Billy Talent,CAW112000153,WMG - WM Canada,crid://rabe.ch/v1/klangbecken#t=clock=20221129T000347.00Z&acrid=b048b2586624de57107217e7968dffce
29/11/22,00:05:32,0:03:00,She Don't Dance,Everyone You Know,"Harvey Kirkby, Rhys Kirkby-Cox, David Roberts",GBARL1900443,RCA Records Label,crid://rabe.ch/v1/klangbecken#t=clock=20221129T000532.00Z&acrid=d03228cefdb79e28703d7c5f7d3fc5df
29/11/22,00:10:42,0:02:30,Time Of Our Lives,Lexer,Lexer,GBEWA2205351,This Never Happened,crid://rabe.ch/v1/klangbecken#t=clock=20221129T001042.00Z&acrid=43b8a821821da065df8b63bb644565ac
29/11/22,00:15:52,0:00:10,Murder Time,Namusoke,Martin Schlegel,DEE880275040,Buback,crid://rabe.ch/v1/klangbecken#t=clock=20221129T001552.00Z&acrid=15293089b6b2a6ac2dd3eca3dfc6344a
29/11/22,00:17:52,0:03:18,Violence,POLIÇA,POLIÇA,GBCSG2200051,MERLIN - Memphis Industries,crid://rabe.ch/v1/klangbecken#t=clock=20221129T001752.00Z&acrid=ce61728e66d073e21a8911e70ce8ddb3
29/11/22,00:25:53,0:04:10,Roman Holiday,Fontaines D.C.,Fontaines D.C.,USBQU2100090,WMG - PTKF,crid://rabe.ch/v1/klangbecken#t=clock=20221129T002553.00Z&acrid=3ad95dda2418954e6f4aecd4702a7803
29/11/22,00:30:53,0:02:59,Impressed,Sporto Kantes,Sporto Kantes,FR06S0400020,UMG - Universal Music Division Island Def Jam,crid://rabe.ch/v1/klangbecken#t=clock=20221129T003053.00Z&acrid=cc4cd4d54b846c181831956e6e75de3e
```

The RABE-CRIDs have the following structure:

`crid://rabe.ch/v1/<show>#t=clock=<timestamp>&acrid=<id-from-acr>`

The `acrid` part is an extension to the RABE-CRID standard and there for our convenience since they tells us where the actual data is from.

I tested the implementation against some time ranges that i know contain some `custom_file` metadata as well as the last month and didn't unearth any issues in several runs. The main question that remains is if we need to talk to SUISA before we add this additional field, but i'm tending to answer that with a clear no because the worst they can do is not rebate our bill and they have been doing that this year already while not providing us any specific feedback.

## FAQ

Q: Bicku, isn't the CRID thing overengineered? 

A: For sure

Q: But, why?

A: CRIDs are both in radioplayer and in RadioEPG. Using the same standard allows us to reference several ETSI and RFC standards for great win.