### PR TITLE
feat: standardize output and add many fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ConfigArgParse==1.5.3
 pytz==2022.7
 requests==2.28.1
+rabe-cridlib==0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ description-file = README.md
 
 [tool:pytest]
 addopts = --doctest-modules --cov=suisa_sendemeldung --pylint --cov-fail-under=100
+filterwarnings =
+    ignore::DeprecationWarning:pylint
+    ignore::pytest.PytestRemovedIn8Warning:pytest_pylint

--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -392,7 +392,7 @@ def get_artist(music):
 def get_isrc(music):
     """Get a valid ISRC from the music record or return an empty string."""
     isrc = ""
-    if music.get("external_ids") and len(music.get("external_ids")) > 0:
+    if music.get("external_ids", {}).get("isrc"):
         isrc = music.get("external_ids").get("isrc")
     elif music.get("isrc"):
         isrc = music.get("isrc")

--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -280,7 +280,6 @@ def parse_filename(args, start_date):
     Returns:
         filename: the filename to use for the csv data
     """
-    print(args.station_name_short)
     if args.filename:
         filename = args.filename
     # depending on date args either append the month or the start_date
@@ -616,8 +615,6 @@ def main():  # pragma: no cover
     if args.email:
         email_subject = start_date.strftime(args.email_subject)
         # generate body
-        print(args.email_text)
-        print(filename)
         text = Template(args.email_text).substitute(
             {
                 "station_name": args.station_name,

--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -424,7 +424,7 @@ def get_csv(data, station_name=""):
         "Marke",
         "Label Code",
         "EAN/GTIN",
-        "vom Sender der Aufnahme selbst zugewiesene Identifikationsnummer",
+        "Identifikationsnummer",
     ]
     csv = StringIO()
     csv_writer = writer(csv, dialect="excel")

--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -50,7 +50,7 @@ Diese Sendemeldung enthält unter anderem folgende Angaben:
 - Sendedauer
 
 Die Datei folgt nach bestem Wissen und Gewissen und wo dies technisch möglich
-ist der Vorlage in "Gemeinsamer Tarif S 2020 - 2023" S. 15 ff.
+ist der Vorlage in "Gemeinsamer Tarif S 2020 - 2023" Anhang 1.
 
 Das Feld ISRC ist dabei mindestens in Fällen wo der ISRC zusammen mit der Aufnahme
 vom Lieferanten der Aufnahme in irgendeiner Form mitgeteilt bzw. mitgeliefert

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -1,8 +1,7 @@
 """Test the suisa_sendemeldung.suisa_sendemeldung module."""
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from email.message import Message
-from os.path import dirname
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from configargparse import ArgumentParser
 from freezegun import freeze_time
@@ -83,29 +82,28 @@ def test_parse_filename():
     # pass filename from cli
     args = ArgumentParser()
     args.filename = "/foo/bar"
+    args.station_name_short = "test"
     filename = suisa_sendemeldung.parse_filename(args, None)
     assert filename == "/foo/bar"
 
     # last_month mode
     args = ArgumentParser()
     args.filename = None
+    args.station_name_short = "test"
     args.last_month = True
     with freeze_time("1996-03-01"):
         filename = suisa_sendemeldung.parse_filename(args, datetime.now())
-    assert (
-        filename
-        == f"{dirname(suisa_sendemeldung.__file__)}/suisa_sendemeldung_March.csv"
-    )
+    assert filename == "test_1996_03.csv"
 
     # start date mode
     args = ArgumentParser()
     args.filename = None
     args.last_month = False
     args.start_date = "1996-03-01"
+    args.station_name_short = "test"
     with freeze_time("1996-03-01"):
         filename = suisa_sendemeldung.parse_filename(args, datetime.now())
-    expected_name = "suisa_sendemeldung_1996-03-01 00:00:00.csv"
-    assert filename == f"{dirname(suisa_sendemeldung.__file__)}/{expected_name}"
+    assert filename == "test_1996-03-01 00:00:00.csv"
 
 
 def test_check_duplicate():
@@ -164,32 +162,40 @@ def test_merge_duplicates():
     assert results[0]["metadata"]["played_duration"] == 20
 
 
-def test_get_csv():
+@patch("cridlib.get")
+def test_get_csv(mock_cridlib_get):
     """Test get_csv."""
+    mock_cridlib_get.return_value = "crid://rabe.ch/v1/test"
 
     # empty data
     data = []
     csv = suisa_sendemeldung.get_csv(data)
+    # pylint: disable=line-too-long
     assert csv == (
-        "sep=,\n"
-        "Sendedatum,Sendezeit,Sendedauer,Titel,Künstler,Komponist,ISRC,Label\r\n"
+        "Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,vom Sender der Aufnahme selbst zugewiesene Identifikationsnummer\r\n"
     )
+    # pylint: enable=line-too-long
+    mock_cridlib_get.assert_not_called()
 
     # bunch of data
+    mock_cridlib_get.reset_mock()
     data = [
         {
             "metadata": {
                 "timestamp_local": "1993-03-01 13:12:00",
+                "timestamp_utc": "1993-03-01 13:12:00",
                 "played_duration": 60,
-                "music": [{"title": "Uhrenvergleich"}],
+                "music": [{"title": "Uhrenvergleich", "acrid": "a1"}],
             }
         },
         {
             "metadata": {
                 "timestamp_local": "1993-03-01 13:37:00",
+                "timestamp_utc": "1993-03-01 13:37:00",
                 "played_duration": 60,
                 "custom_files": [
                     {
+                        "acrid": "a2",
                         "title": "Meme Dub",
                         "artist": "Da Gang",
                         "contributors": {
@@ -197,6 +203,7 @@ def test_get_csv():
                                 "Da Composah",
                             ]
                         },
+                        "release_date": "2023",
                         "external_ids": {
                             "isrc": "id-from-well-published-isrc-database"
                         },
@@ -207,10 +214,16 @@ def test_get_csv():
         {
             "metadata": {
                 "timestamp_local": "1993-03-01 16:20:00",
+                "timestamp_utc": "1993-03-01 16:20:00",
                 "played_duration": 60,
                 "music": [
                     {
+                        "acrid": "a3",
                         "title": "Bubbles",
+                        "album": {
+                            "name": "Da Alboom",
+                        },
+                        "release_date": "2022-12-13",
                         "artists": [
                             {
                                 "name": "Mary's Surprise Act",
@@ -221,21 +234,39 @@ def test_get_csv():
                         ],
                         "isrc": "important-globally-well-managed-id",
                         "label": "Jane Records",
+                        "external_ids": {
+                            "upc": "greedy-capitalist-number",
+                        },
                     }
                 ],
             }
         },
     ]
-    csv = suisa_sendemeldung.get_csv(data)
+    csv = suisa_sendemeldung.get_csv(data, station_name="Station Name")
     # pylint: disable=line-too-long
     assert csv == (
-        "sep=,\n"
-        "Sendedatum,Sendezeit,Sendedauer,Titel,Künstler,Komponist,ISRC,Label\r\n"
-        "01/03/93,13:12:00,0:01:00,Uhrenvergleich,,,,\r\n"
-        "01/03/93,13:37:00,0:01:00,Meme Dub,Da Gang,Da Composah,id-from-well-published-isrc-database,\r\n"
-        '01/03/93,16:20:00,0:01:00,Bubbles,"Mary\'s Surprise Act, Climmy Jiff","Mary\'s Surprise Act, Climmy Jiff",important-globally-well-managed-id,Jane Records\r\n'
+        "Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,vom Sender der Aufnahme selbst zugewiesene Identifikationsnummer\r\n"
+        "Uhrenvergleich,,,,Station Name,19930301,0:01:00,13:12:00,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        "Meme Dub,Da Composah,Da Gang,,Station Name,19930301,0:01:00,13:37:00,,id-from-well-published-isrc-database,,,,,2023,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        'Bubbles,,"Mary\'s Surprise Act, Climmy Jiff",,Station Name,19930301,0:01:00,16:20:00,,important-globally-well-managed-id,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,crid://rabe.ch/v1/test\r\n'
     )
     # pylint: enable=line-too-long
+    mock_cridlib_get.assert_has_calls(
+        [
+            call(
+                timestamp=datetime(1993, 3, 1, 13, 12, tzinfo=timezone.utc),
+                fragment="acrid=a1",
+            ),
+            call(
+                timestamp=datetime(1993, 3, 1, 13, 37, tzinfo=timezone.utc),
+                fragment="acrid=a2",
+            ),
+            call(
+                timestamp=datetime(1993, 3, 1, 16, 20, tzinfo=timezone.utc),
+                fragment="acrid=a3",
+            ),
+        ]
+    )
 
 
 def test_create_message():

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -244,6 +244,7 @@ def test_get_csv(mock_cridlib_get):
         {
             "metadata": {
                 "timestamp_local": "1993-03-01 17:17:17",
+                "timestamp_utc": "1993-03-01 17:17:17",
                 "played_duration": 60,
                 "custom_files": [
                     {
@@ -260,7 +261,7 @@ def test_get_csv(mock_cridlib_get):
         "Uhrenvergleich,,,,Station Name,19930301,0:01:00,13:12:00,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
         "Meme Dub,Da Composah,Da Gang,,Station Name,19930301,0:01:00,13:37:00,,id-from-well-published-isrc-database,,,,,2023,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
         'Bubbles,,"Mary\'s Surprise Act, Climmy Jiff",,Station Name,19930301,0:01:00,16:20:00,,important-globally-well-managed-id,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,crid://rabe.ch/v1/test\r\n'
-        ",,Artists as string not list,,Station Name,19930301,17:17:17,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        ",,Artists as string not list,,Station Name,19930301,0:01:00,17:17:17,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
     )
     # pylint: enable=line-too-long
     mock_cridlib_get.assert_has_calls(

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -172,7 +172,7 @@ def test_get_csv(mock_cridlib_get):
     csv = suisa_sendemeldung.get_csv(data)
     # pylint: disable=line-too-long
     assert csv == (
-        "Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,vom Sender der Aufnahme selbst zugewiesene Identifikationsnummer\r\n"
+        "Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,Identifikationsnummer\r\n"
     )
     # pylint: enable=line-too-long
     mock_cridlib_get.assert_not_called()
@@ -257,7 +257,7 @@ def test_get_csv(mock_cridlib_get):
     csv = suisa_sendemeldung.get_csv(data, station_name="Station Name")
     # pylint: disable=line-too-long
     assert csv == (
-        "Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,vom Sender der Aufnahme selbst zugewiesene Identifikationsnummer\r\n"
+        "Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,Identifikationsnummer\r\n"
         "Uhrenvergleich,,,,Station Name,19930301,0:01:00,13:12:00,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
         "Meme Dub,Da Composah,Da Gang,,Station Name,19930301,0:01:00,13:37:00,,id-from-well-published-isrc-database,,,,,2023,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
         'Bubbles,,"Mary\'s Surprise Act, Climmy Jiff",,Station Name,19930301,0:01:00,16:20:00,,important-globally-well-managed-id,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,crid://rabe.ch/v1/test\r\n'


### PR DESCRIPTION
Includes a huge new amount of fields as per the tariff and also updates our code to directly include a german email template.

Having the template in code should help us closely manage future change to it should we need to adopt it if the tariff gets updated.

There are also a bunch of fields that acr-cloud doesn't currently deliver, but most of those are not in the "official" list as per the tariff and only in the example.

This drafts what i'm hoping will fix most stuff...

* fixes #187 
* fixes #188 