### PR TITLE
fix: handle artists from custom_files

### DIFF
--- a/suisa_sendemeldung/acrclient.py
+++ b/suisa_sendemeldung/acrclient.py
@@ -34,9 +34,10 @@ class ACRClient:
         """
         if requested_date is None:
             requested_date = self.default_date
-        url_params = dict(
-            access_key=self.access_key, date=requested_date.strftime("%Y%m%d")
-        )
+        url_params = {
+            "access_key": self.access_key,
+            "date": requested_date.strftime("%Y%m%d"),
+        }
         url = f"https://api.acrcloud.com/v1/monitor-streams/{stream_id}/results"
         response = requests.get(url=url, params=url_params, timeout=10)
         response.raise_for_status()

--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -269,7 +269,7 @@ def get_artist(music):
         artists = music.get("artists")
         if isinstance(artists, list):
             artist = ", ".join([a.get("name") for a in artists])
-        else:  # pragma: no cover
+        else:
             # Yet another 'wrong' entry in the database:
             # artists in custom_files was sometimes recorded as single value
             # @TODO also remove once way in the past? (2023-01-31)

--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -255,6 +255,36 @@ def merge_duplicates(data):
     return data
 
 
+def get_artist(music):
+    """Get artist from a given dict.
+
+    Arguments:
+        music: music dict from API
+
+    Returns:
+        artist: string representing the artist
+    """
+    artist = ""
+    if music.get("artists") is not None:
+        artists = music.get("artists")
+        if isinstance(artists, list):
+            artist = ", ".join([a.get("name") for a in artists])
+        else:  # pragma: no cover
+            # Yet another 'wrong' entry in the database:
+            # artists in custom_files was sometimes recorded as single value
+            # @TODO also remove once way in the past? (2023-01-31)
+            artist = artists
+    elif music.get("artist") is not None:
+        artist = music.get("artist")
+    elif music.get("Artist") is not None:  # pragma: no cover
+        # Uppercase is a hack needed for Jun 2021 since there is a 'wrong' entry
+        # in the database. Going forward the record will be available as 'artist'
+        # in lowercase.
+        # @TODO remove once is waaaay in the past
+        artist = music.get("Artist")
+    return artist
+
+
 # all local vars are required, eight are already used for the csv entries
 # pylint: disable-msg=too-many-locals
 def get_csv(data):
@@ -297,18 +327,7 @@ def get_csv(data):
             music = metadata.get("custom_files")[0]
         title = music.get("title")
 
-        if music.get("artists") is not None:
-            artist = ", ".join([a.get("name") for a in music.get("artists")])
-        elif music.get("artist") is not None:
-            artist = music.get("artist")
-        elif music.get("Artist") is not None:  # pragma: no cover
-            # Uppercase is a hack needed for Jun 2021 since there is a 'wrong' entry
-            # in the database. Going forward the record will be available as 'artist'
-            # in lowercase.
-            # @TODO remove once is waaaay in the past
-            artist = music.get("Artist")
-        else:
-            artist = ""
+        artist = get_artist(music)
 
         if music.get("contributors") and music.get("contributors").get("composers"):
             composer = ", ".join(music.get("contributors").get("composers"))

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -225,6 +225,17 @@ def test_get_csv():
                 ],
             }
         },
+        {
+            "metadata": {
+                "timestamp_local": "1993-03-01 17:17:17",
+                "played_duration": 60,
+                "custom_files": [
+                    {
+                        "artists": "Artists as string not list",
+                    }
+                ],
+            }
+        },
     ]
     csv = suisa_sendemeldung.get_csv(data)
     # pylint: disable=line-too-long
@@ -234,6 +245,7 @@ def test_get_csv():
         "01/03/93,13:12:00,0:01:00,Uhrenvergleich,,,,\r\n"
         "01/03/93,13:37:00,0:01:00,Meme Dub,Da Gang,Da Composah,id-from-well-published-isrc-database,\r\n"
         '01/03/93,16:20:00,0:01:00,Bubbles,"Mary\'s Surprise Act, Climmy Jiff","Mary\'s Surprise Act, Climmy Jiff",important-globally-well-managed-id,Jane Records\r\n'
+        "01/03/93,17:17:17,0:01:00,,Artists as string not list,Artists as string not list,,\r\n"
     )
     # pylint: enable=line-too-long
 


### PR DESCRIPTION
As seen in #200, we have `custom_files` where the artists are represented by a single string instead of a list. This PR handles this issue correctly.