### PR TITLE
feat: only include valid iso3901 ISRC fields in output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ConfigArgParse==1.5.3
+iso3901==0.2.0
 pytz==2022.7.1
 requests==2.28.2

--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -18,6 +18,7 @@ from os.path import basename, expanduser
 from smtplib import SMTP
 
 from configargparse import ArgumentParser
+from iso3901 import ISRC
 
 from .acrclient import ACRClient
 
@@ -285,6 +286,20 @@ def get_artist(music):
     return artist
 
 
+def get_isrc(music):
+    """Get a valid ISRC from the music record or return an empty string."""
+    isrc = ""
+    if music.get("external_ids") and len(music.get("external_ids")) > 0:
+        isrc = music.get("external_ids").get("isrc")
+    elif music.get("isrc"):
+        isrc = music.get("isrc")
+    if isrc and isrc[:4] == "ISRC":
+        isrc = isrc[4:]
+    if not ISRC.validate(isrc):
+        isrc = ""
+    return isrc
+
+
 # all local vars are required, eight are already used for the csv entries
 # pylint: disable-msg=too-many-locals
 def get_csv(data):
@@ -334,12 +349,7 @@ def get_csv(data):
         else:
             composer = artist
 
-        if music.get("external_ids") and len(music.get("external_ids")) > 0:
-            isrc = music.get("external_ids").get("isrc")
-        elif music.get("isrc"):
-            isrc = music.get("isrc")
-        else:
-            isrc = ""
+        isrc = get_isrc(music)
         label = music.get("label")
 
         csv_writer.writerow(

--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -293,8 +293,19 @@ def get_isrc(music):
         isrc = music.get("external_ids").get("isrc")
     elif music.get("isrc"):
         isrc = music.get("isrc")
+    # was a list with a singular entry for a while back in 2021
+    if isinstance(isrc, list):
+        isrc = isrc[0]
+    # some records contain the "ISRC" prefix that is described as legacy
+    # in the ISRC handbook from IFPI.
     if isrc and isrc[:4] == "ISRC":
         isrc = isrc[4:]
+    # take care of cases where the isrc is space delimited even though the
+    # record is technically wrong but happens often enough to warrant this
+    # hack.
+    if isrc:
+        isrc = isrc.replace(" ", "")
+
     if not ISRC.validate(isrc):
         isrc = ""
     return isrc

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -304,12 +304,15 @@ def test_send_message():
     "test_music,expected",
     [
         ({"external_ids": {"isrc": "AA6Q72000047"}}, "AA6Q72000047"),
-        ({"isrc": "AA6Q72000047"}, "AA6Q72000047"),
+        ({"external_ids": {"isrc": ["AA6Q72000047"]}}, "AA6Q72000047"),
+        ({"external_ids": {"isrc": "AA 6Q7 20 00047"}}, "AA6Q72000047"),
+        ({"external_ids": {"isrc": "ISRCAA6Q72000047"}}, "AA6Q72000047"),
+        ({"external_ids": {"isrc": "123456789-1"}}, ""),
         ({"isrc": "AA6Q72000047"}, "AA6Q72000047"),
         ({"isrc": ["AA6Q72000047"]}, "AA6Q72000047"),
         ({"isrc": "ISRCAA6Q72000047"}, "AA6Q72000047"),
-        ({"isrc": "123456789-1"}, ""),
         ({"isrc": "AA 6Q7 20 00047"}, "AA6Q72000047"),
+        ({"isrc": "123456789-1"}, ""),
     ],
 )
 def test_get_isrc(test_music, expected):

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from configargparse import ArgumentParser
 from freezegun import freeze_time
+from pytest import mark
 
 from suisa_sendemeldung import suisa_sendemeldung
 
@@ -197,9 +198,7 @@ def test_get_csv():
                                 "Da Composah",
                             ]
                         },
-                        "external_ids": {
-                            "isrc": "id-from-well-published-isrc-database"
-                        },
+                        "external_ids": {"isrc": "AA6Q72000047"},
                     }
                 ],
             }
@@ -219,7 +218,7 @@ def test_get_csv():
                                 "name": "Climmy Jiff",
                             },
                         ],
-                        "isrc": "important-globally-well-managed-id",
+                        "isrc": "AA6Q72000047",
                         "label": "Jane Records",
                     }
                 ],
@@ -243,8 +242,8 @@ def test_get_csv():
         "sep=,\n"
         "Sendedatum,Sendezeit,Sendedauer,Titel,Künstler,Komponist,ISRC,Label\r\n"
         "01/03/93,13:12:00,0:01:00,Uhrenvergleich,,,,\r\n"
-        "01/03/93,13:37:00,0:01:00,Meme Dub,Da Gang,Da Composah,id-from-well-published-isrc-database,\r\n"
-        '01/03/93,16:20:00,0:01:00,Bubbles,"Mary\'s Surprise Act, Climmy Jiff","Mary\'s Surprise Act, Climmy Jiff",important-globally-well-managed-id,Jane Records\r\n'
+        "01/03/93,13:37:00,0:01:00,Meme Dub,Da Gang,Da Composah,AA6Q72000047,\r\n"
+        '01/03/93,16:20:00,0:01:00,Bubbles,"Mary\'s Surprise Act, Climmy Jiff","Mary\'s Surprise Act, Climmy Jiff",AA6Q72000047,Jane Records\r\n'
         "01/03/93,17:17:17,0:01:00,,Artists as string not list,Artists as string not list,,\r\n"
     )
     # pylint: enable=line-too-long
@@ -299,3 +298,20 @@ def test_send_message():
         ctx = mock.return_value.__enter__.return_value
         ctx.starttls.assert_called_once()
         ctx.login.assert_called_once_with("test@example.org", "password")
+
+
+@mark.parametrize(
+    "test_music,expected",
+    [
+        ({"external_ids": {"isrc": "AA6Q72000047"}}, "AA6Q72000047"),
+        ({"isrc": "AA6Q72000047"}, "AA6Q72000047"),
+        ({"isrc": "AA6Q72000047"}, "AA6Q72000047"),
+        ({"isrc": "ISRCAA6Q72000047"}, "AA6Q72000047"),
+        ({"isrc": "123456789-1"}, ""),
+    ],
+)
+def test_get_isrc(test_music, expected):
+    """Test get_isrc."""
+
+    isrc = suisa_sendemeldung.get_isrc(test_music)
+    assert isrc == expected

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -306,8 +306,10 @@ def test_send_message():
         ({"external_ids": {"isrc": "AA6Q72000047"}}, "AA6Q72000047"),
         ({"isrc": "AA6Q72000047"}, "AA6Q72000047"),
         ({"isrc": "AA6Q72000047"}, "AA6Q72000047"),
+        ({"isrc": ["AA6Q72000047"]}, "AA6Q72000047"),
         ({"isrc": "ISRCAA6Q72000047"}, "AA6Q72000047"),
         ({"isrc": "123456789-1"}, ""),
+        ({"isrc": "AA 6Q7 20 00047"}, "AA6Q72000047"),
     ],
 )
 def test_get_isrc(test_music, expected):


### PR DESCRIPTION
Uses the new [iso3901](https://github.com/Tagger-phile/py-iso3901) to validate our ISRC records before publishing, thus ensuring that we don't send any garbage provided to us. The linked ticket has a description of the amount of records affected by this and shows why the implementation in this PR should suffice for our needs.

* fixes #205 