### PR TITLE
fix: support strings in album field

### DIFF
--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -502,7 +502,10 @@ def get_csv(data, station_name=""):
         label = music.get("label")
 
         # load some "best-effort" fields
-        album = music.get("album", {}).get("name", "")
+        album = music.get("album", "")
+        # it's a dict if it's from the ACRCloud bucket, a string if from a custom bucket
+        if isinstance(album, dict):
+            album = album.get("name", "")
         upc = music.get("external_ids", {}).get("upc", "")
         release_date = funge_release_date(music.get("release_date", ""))
 

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -215,6 +215,7 @@ def test_get_csv(mock_cridlib_get):
                         "acrid": "a2",
                         "title": "Meme Dub",
                         "artist": "Da Gang",
+                        "album": "album, but string",
                         "contributors": {
                             "composers": [
                                 "Da Composah",
@@ -274,7 +275,7 @@ def test_get_csv(mock_cridlib_get):
     assert csv == (
         "Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,Identifikationsnummer\r\n"
         "Uhrenvergleich,,,,Station Name,19930301,0:01:00,13:12:00,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
-        "Meme Dub,Da Composah,Da Gang,,Station Name,19930301,0:01:00,13:37:00,,AA6Q72000047,,,,,2023,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        'Meme Dub,Da Composah,Da Gang,,Station Name,19930301,0:01:00,13:37:00,,AA6Q72000047,,,,,2023,"album, but string",,,,,,,,,crid://rabe.ch/v1/test\r\n'
         'Bubbles,,"Mary\'s Surprise Act, Climmy Jiff",,Station Name,19930301,0:01:00,16:20:00,,AA6Q72000047,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,crid://rabe.ch/v1/test\r\n'
         ",,Artists as string not list,,Station Name,19930301,0:01:00,17:17:17,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
     )


### PR DESCRIPTION
This is specific to our custom bucket, but the code for music and custom buckets is currently shared in both implementation paths.