### PR TITLE
fix: add labels for container image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Prepare additional Metadata
+        id: additional_meta
+        run: |
+          echo created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_OUTPUT
+
       - name: Prepare Image Metadata
         id: meta
         uses: docker/metadata-action@v4
@@ -36,6 +41,16 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+          labels: |
+            name=suisasendemeldung
+            summary=${{ github.event.repository.description }}
+            url=${{ github.event.repository.html_url }}
+            vcs-ref=${{ github.sha }}
+            revision=${{ github.sha }}
+            release=${{ github.sha }}
+            build-date=${{ steps.additional_meta.outputs.created }}
+            io.k8s.display-name=RaBe SUISA Sendemeldung
+            io.k8s.description=${{ github.event.repository.description }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
It was missing some labels so the image wasn't properly linked with the repo leading to a denied push.

I reconfigure packages to allow the push, this fixes it so nothing similar happens in future.

While i was at it i also added a bunch of other standard labels that most other images have.