### PR TITLE
fix: date formatting iso year-week calender

### DIFF
--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -731,9 +731,9 @@ def main():  # pragma: no cover
             {
                 "station_name": args.station_name,
                 "month": format_date(start_date, format="MMMM", locale=args.locale),
-                "year": format_date(start_date, format="YYYY", locale=args.locale),
+                "year": format_date(start_date, format="yyyy", locale=args.locale),
                 "previous_year": format_date(
-                    start_date - timedelta(days=365), format="YYYY", locale=args.locale
+                    start_date - timedelta(days=365), format="yyyy", locale=args.locale
                 ),
                 "in_three_months": format_date(
                     end_date + relativedelta(months=+3),


### PR DESCRIPTION
For January 1st it would format the year wrong. Documentation is here: https://babel.pocoo.org/en/latest/dates.html#date-fields
```python
>>> from babel.dates import format_date
>>> from datetime import datetime
>>> d = datetime(year=2023, month=1, day=1)
>>> format_date(d,format="YYYY")
'2022'
>>> format_date(d,format="yyyy")
'2023'
```