### PR TITLE
fix: format duration according to SUISA requirements

### DIFF
--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -491,7 +491,10 @@ def get_csv(data, station_name=""):
 
         ts_date = timestamp.strftime("%Y%m%d")
         ts_time = timestamp.strftime("%H:%M:%S")
-        duration = timedelta(seconds=metadata.get("played_duration"))
+        hours, remainder = divmod(metadata.get("played_duration"), 60 * 60)
+        minutes, seconds = divmod(remainder, 60)
+        # required format of duration field: hh:mm.ss
+        duration = f"{hours:02}:{minutes:02}.{seconds:02}"
 
         try:
             music = metadata.get("music")[0]

--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -493,8 +493,8 @@ def get_csv(data, station_name=""):
         ts_time = timestamp.strftime("%H:%M:%S")
         hours, remainder = divmod(metadata.get("played_duration"), 60 * 60)
         minutes, seconds = divmod(remainder, 60)
-        # required format of duration field: hh:mm.ss
-        duration = f"{hours:02}:{minutes:02}.{seconds:02}"
+        # required format of duration field: hh:mm:ss
+        duration = f"{hours:02}:{minutes:02}:{seconds:02}"
 
         try:
             music = metadata.get("music")[0]

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -274,10 +274,10 @@ def test_get_csv(mock_cridlib_get):
     # pylint: disable=line-too-long
     assert csv == (
         "Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,Identifikationsnummer\r\n"
-        "Uhrenvergleich,,,,Station Name,19930301,0:01:00,13:12:00,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
-        'Meme Dub,Da Composah,Da Gang,,Station Name,19930301,0:01:00,13:37:00,,AA6Q72000047,,,,,,"album, but string",,,,,,,,,crid://rabe.ch/v1/test\r\n'
-        'Bubbles,"Mary\'s Surprise Act, Climmy Jiff","Mary\'s Surprise Act, Climmy Jiff",,Station Name,19930301,0:01:00,16:20:00,,AA6Q72000047,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,crid://rabe.ch/v1/test\r\n'
-        ",Artists as string not list,Artists as string not list,,Station Name,19930301,0:01:00,17:17:17,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        "Uhrenvergleich,,,,Station Name,19930301,00:01.00,13:12:00,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        'Meme Dub,Da Composah,Da Gang,,Station Name,19930301,00:01.00,13:37:00,,AA6Q72000047,,,,,,"album, but string",,,,,,,,,crid://rabe.ch/v1/test\r\n'
+        'Bubbles,"Mary\'s Surprise Act, Climmy Jiff","Mary\'s Surprise Act, Climmy Jiff",,Station Name,19930301,00:01.00,16:20:00,,AA6Q72000047,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,crid://rabe.ch/v1/test\r\n'
+        ",Artists as string not list,Artists as string not list,,Station Name,19930301,00:01.00,17:17:17,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
     )
     # pylint: enable=line-too-long
     mock_cridlib_get.assert_has_calls(

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -283,11 +283,11 @@ def test_get_csv(mock_cridlib_get):
     # pylint: disable=line-too-long
     assert csv == (
         "Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,Identifikationsnummer\r\n"
-        "Uhrenvergleich,,,,Station Name,19930301,00:01.00,13:12:00,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
-        'Meme Dub,Da Composah,Da Gang,,Station Name,19930301,00:01.00,13:37:00,,AA6Q72000047,,,,,,"album, but string",,,,,,,,,crid://rabe.ch/v1/test\r\n'
-        'Bubbles,"Mary\'s Surprise Act, Climmy Jiff","Mary\'s Surprise Act, Climmy Jiff",,Station Name,19930301,00:01.00,16:20:00,,AA6Q72000047,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,crid://rabe.ch/v1/test\r\n'
-        ",Artists as string not list,Artists as string not list,,Station Name,19930301,00:01.00,17:17:17,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
-        "Long Playing,,,,Station Name,19930301,19:48.57,18:18:18,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        "Uhrenvergleich,,,,Station Name,19930301,00:01:00,13:12:00,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        'Meme Dub,Da Composah,Da Gang,,Station Name,19930301,00:01:00,13:37:00,,AA6Q72000047,,,,,,"album, but string",,,,,,,,,crid://rabe.ch/v1/test\r\n'
+        'Bubbles,"Mary\'s Surprise Act, Climmy Jiff","Mary\'s Surprise Act, Climmy Jiff",,Station Name,19930301,00:01:00,16:20:00,,AA6Q72000047,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,crid://rabe.ch/v1/test\r\n'
+        ",Artists as string not list,Artists as string not list,,Station Name,19930301,00:01:00,17:17:17,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        "Long Playing,,,,Station Name,19930301,19:48:57,18:18:18,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
     )
     # pylint: enable=line-too-long
     mock_cridlib_get.assert_has_calls(

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -264,9 +264,18 @@ def test_get_csv(mock_cridlib_get):
                 "played_duration": 60,
                 "custom_files": [
                     {
+                        "acrid": "a4",
                         "artists": "Artists as string not list",
                     }
                 ],
+            }
+        },
+        {
+            "metadata": {
+                "timestamp_local": "1993-03-01 18:18:18",
+                "timestamp_utc": "1993-03-01 18:18:18",
+                "played_duration": 71337,
+                "music": [{"title": "Long Playing", "acrid": "a5"}],
             }
         },
     ]
@@ -278,6 +287,7 @@ def test_get_csv(mock_cridlib_get):
         'Meme Dub,Da Composah,Da Gang,,Station Name,19930301,00:01.00,13:37:00,,AA6Q72000047,,,,,,"album, but string",,,,,,,,,crid://rabe.ch/v1/test\r\n'
         'Bubbles,"Mary\'s Surprise Act, Climmy Jiff","Mary\'s Surprise Act, Climmy Jiff",,Station Name,19930301,00:01.00,16:20:00,,AA6Q72000047,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,crid://rabe.ch/v1/test\r\n'
         ",Artists as string not list,Artists as string not list,,Station Name,19930301,00:01.00,17:17:17,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
+        "Long Playing,,,,Station Name,19930301,19:48.57,18:18:18,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test\r\n"
     )
     # pylint: enable=line-too-long
     mock_cridlib_get.assert_has_calls(
@@ -293,6 +303,14 @@ def test_get_csv(mock_cridlib_get):
             call(
                 timestamp=datetime(1993, 3, 1, 16, 20, tzinfo=timezone.utc),
                 fragment="acrid=a3",
+            ),
+            call(
+                timestamp=datetime(1993, 3, 1, 17, 17, 17, tzinfo=timezone.utc),
+                fragment="acrid=a4",
+            ),
+            call(
+                timestamp=datetime(1993, 3, 1, 18, 18, 18, tzinfo=timezone.utc),
+                fragment="acrid=a5",
             ),
         ]
     )


### PR DESCRIPTION
SUISA wants the duration field formatted as hh:mm.ss