### PR TITLE
feat: allow newline character in footer

### DIFF
--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -741,7 +741,7 @@ def main():  # pragma: no cover
                     locale=args.locale,
                 ),
                 "responsible_email": args.responsible_email,
-                "email_footer": args.email_footer,
+                "email_footer": args.email_footer.replace("\\n", "\n"),
             }
         )
         msg = create_message(


### PR DESCRIPTION
Can be use with `--footer 'a\nb\nc'`

@hairmare That's what I came up with to have newline characters in the footer. Do you have any better solution?