### PR TITLE
feat: use setuptools_scm to set version of python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(
     author="RaBe IT-Reaktion",
     author_email="it@rabe.ch",
     license="MIT",
+    setup_requires=["setuptools_scm"],
+    use_scm_version=True,
     install_requires=requirements,
     packages=["suisa_sendemeldung"],
     entry_points={


### PR DESCRIPTION
This should also fix the issues with pushing to the package registry as it always generates a new version based on the Git tag

```shell
$ python3 setup.py --version
0.8.2.dev1+g40c6282
```