### PR TITLE
fix(composer): read composer data from works[].creators[].name if contributors.composer is empty

### DIFF
--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -503,7 +503,13 @@ def get_csv(data, station_name=""):
 
         composer = ", ".join(music.get("contributors", {}).get("composers", ""))
         if not composer:
-            composer = artist
+            creators = []
+            for work in music.get("works", []):
+                for creator in work.get("creators", []):
+                    name = creator.get("name", "")
+                    if name:
+                        creators.append(name)
+            composer = ", ".join(creators)
 
         isrc = get_isrc(music)
         label = music.get("label")


### PR DESCRIPTION
This is what i assume the creators field recommended by the ACRcloud support desk to be.