### PR TITLE
feat(email): allow multiple recipients in To, Cc, and Bcc header

### DIFF
--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -18,6 +18,7 @@ from io import BytesIO, StringIO
 from os.path import basename, expanduser
 from smtplib import SMTP
 from string import Template
+from typing import Optional
 
 import cridlib
 import pytz
@@ -192,16 +193,19 @@ def get_arguments(parser: ArgumentParser):  # pragma: no cover
     parser.add_argument(
         "--email-to",
         env_var="EMAIL_TO",
+        nargs="+",
         help="the recipients of the email",
     )
     parser.add_argument(
         "--email-cc",
         env_var="EMAIL_CC",
+        nargs="+",
         help="the cc recipients of the email",
     )
     parser.add_argument(
         "--email-bcc",
         env_var="EMAIL_BCC",
+        nargs="+",
         help="the bcc recipients of the email",
     )
     parser.add_argument(
@@ -739,14 +743,14 @@ def get_email_attachment(filename: str, filetype: str, data) -> MIMEBase:
 # pylint: disable-msg=too-many-arguments,invalid-name
 def create_message(
     sender: str,
-    recipient: str,
+    recipient: list[str],
     subject: str,
     text: str,
     filename: str,
     filetype: str,
-    data,
-    cc: str | None = None,
-    bcc: str | None = None,
+    data: str,
+    cc: Optional[list[str]] = None,
+    bcc: Optional[list[str]] = None,
 ) -> MIMEMultipart:
     """Create email message.
 
@@ -765,11 +769,11 @@ def create_message(
     """
     msg = MIMEMultipart()
     msg["From"] = sender
-    msg["To"] = recipient
+    msg["To"] = ", ".join(recipient)
     if cc:
-        msg["Cc"] = cc
+        msg["Cc"] = ", ".join(cc)
     if bcc:
-        msg["Bcc"] = bcc
+        msg["Bcc"] = ", ".join(bcc)
     msg["Date"] = formatdate(localtime=True)
     msg["Subject"] = subject
     # set body

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -425,14 +425,14 @@ def test_get_email_attachment():
 def test_create_message():
     """Test create_message."""
     sender = "from@example.org"
-    recipient = "long-arm-of-music-industry@example.com"
+    recipient = ["long-arm-of-music-industry@example.com"]
     subject = "subject"
     text = "text"
     filename = "/tmp/filename"
     filetype = "csv"
     data = "data"
-    carbon_copy = "cc@example.org"
-    bcc = "bcc@example.org"
+    carbon_copy = ["cc@example.org"]
+    bcc = ["bcc@example.org", "bcc@example.net"]
 
     msg = suisa_sendemeldung.create_message(
         sender,
@@ -446,10 +446,10 @@ def test_create_message():
         bcc,
     )
     assert msg.get("From") == sender
-    assert msg.get("To") == recipient
+    assert msg.get("To") == recipient[0]
     assert msg.get("Subject") == subject
-    assert msg.get("Cc") == carbon_copy
-    assert msg.get("Bcc") == bcc
+    assert msg.get("Cc") == carbon_copy[0]
+    assert msg.get("Bcc") == "bcc@example.org, bcc@example.net"
 
 
 def test_send_message():


### PR DESCRIPTION
Also adds a bunch of type hinting for the relevant paths.

* fixes #290