### PR TITLE
fix: Allow stream_id to be 9-10 chars

### DIFF
--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -100,9 +100,9 @@ def validate_arguments(parser, args):
             )
         )
     # check length of stream_id
-    if not len(args.stream_id) == 9:
+    if len(args.stream_id) not in [9, 10]:
         msgs.append(
-            f"wrong format on stream_id, expected 9 characters but got {len(args.stream_id)}"
+            f"wrong format on stream_id, expected 9 or 10 characters but got {len(args.stream_id)}"
         )
     # one output option has to be set
     if not (args.file or args.email or args.stdout):

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -33,7 +33,7 @@ def test_validate_arguments():
         mock.error.assert_called_once_with(
             "\n"
             "- wrong format on bearer_token, expected larger than 32 characters but got 31\n"
-            "- wrong format on stream_id, expected 9 characters but got 12\n"
+            "- wrong format on stream_id, expected 9 or 10 characters but got 12\n"
             "- no output option has been set, specify one of --file, --email or --stdout\n"
             "- argument --last_month not allowed with --start_date or --end_date"
         )
@@ -45,7 +45,7 @@ def test_validate_arguments():
         mock.error.assert_called_once_with(
             "\n"
             "- wrong format on bearer_token, expected larger than 32 characters but got 31\n"
-            "- wrong format on stream_id, expected 9 characters but got 12\n"
+            "- wrong format on stream_id, expected 9 or 10 characters but got 12\n"
             "- xlsx cannot be printed to stdout, please set --filetype to csv\n"
             "- argument --last_month not allowed with --start_date or --end_date"
         )


### PR DESCRIPTION
I opted for allowing stream_id to have 10 chars assuming that needing to allow 11 will not happen soon.

* fixes #393