### PR TITLE
feat: Add --crid-mode flag to bypass cridlib

### DIFF
--- a/tests/__snapshots__/test_suisa_sendemeldung.ambr
+++ b/tests/__snapshots__/test_suisa_sendemeldung.ambr
@@ -13,7 +13,7 @@
                 [--responsible-email RESPONSIBLE_EMAIL]
                 [--start-date START_DATE] [--end-date END_DATE] [--last-month]
                 --timezone TIMEZONE [--locale LOCALE] [--filename FILENAME]
-                [--stdout]
+                [--stdout] [--crid-mode CRID_MODE]
   
   options:
     -h, --help            show this help message and exit
@@ -81,6 +81,9 @@
                           last month - <station_name_short>_<start_date>.csv
                           else [env var: FILENAME]
     --stdout              also print to stdout [env var: STDOUT]
+    --crid-mode CRID_MODE
+                          Choose how to generate CRID identifiers (cridlib or
+                          local) [env var: CRID_MODE]
   
    In general, command-line values override environment variables which override
   defaults.
@@ -103,6 +106,19 @@
   Long Playing,,,,Station Name,19930301,19:48:57,18:18:18,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test
   composer in works,Worker,,,Station Name,19930301,19:48:57,18:18:18,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test
   composer better in works,composer,same,,Station Name,19930301,19:48:57,18:18:18,,,,,,,,,,,,,,,,,crid://rabe.ch/v1/test
+  
+  '''
+# ---
+# name: test_get_csv.2
+  '''
+  Titel,Komponist,Interpret,Interpreten-Info,Sender,Sendedatum,Sendedauer,Sendezeit,Werkverzeichnisangaben,ISRC,Label,CD ID / Katalog-Nummer,Aufnahmedatum,Aufnahmeland,Erstveröffentlichungsdatum,Titel des Tonträgers (Albumtitel),Autor Text,Track Nummer,Genre,Programm,Bestellnummer,Marke,Label Code,EAN/GTIN,Identifikationsnummer
+  Uhrenvergleich,,,,Station Name,19930301,00:01:00,13:12:00,,,,,,,,,,,,,,,,,1993-03-01T13:12:00+00:00#acrid=a1
+  Meme Dub,Da Composah,Da Gang,,Station Name,19930301,00:01:00,13:37:00,,DEZ650710376,,,,,,"album, but string",,,,,,,,,1993-03-01T13:37:00+00:00#acrid=a2
+  Bubbles,,"Mary's Surprise Act, Climmy Jiff",,Station Name,19930301,00:01:00,16:20:00,,DEZ650710376,Jane Records,,,,20221213,Da Alboom,,,,,,,,greedy-capitalist-number,1993-03-01T16:20:00+00:00#acrid=a3
+  ,,Artists as string not list,,Station Name,19930301,00:01:00,17:17:17,,,,,,,,,,,,,,,,,1993-03-01T17:17:17+00:00#acrid=a4
+  Long Playing,,,,Station Name,19930301,19:48:57,18:18:18,,,,,,,,,,,,,,,,,1993-03-01T18:18:18+00:00#acrid=a5
+  composer in works,Worker,,,Station Name,19930301,19:48:57,18:18:18,,,,,,,,,,,,,,,,,1993-03-01T18:18:18+00:00#acrid=a6
+  composer better in works,composer,same,,Station Name,19930301,19:48:57,18:18:18,,,,,,,,,,,,,,,,,1993-03-01T18:18:18+00:00#acrid=a6
   
   '''
 # ---

--- a/tests/test_suisa_sendemeldung.py
+++ b/tests/test_suisa_sendemeldung.py
@@ -29,12 +29,14 @@ def test_validate_arguments():
     # last_month is in conflict with start_date and end_date
     args.last_month = True
     args.start_date = date(1993, 3, 1)
+    args.crid_mode = "invalid"
     with patch("suisa_sendemeldung.suisa_sendemeldung.ArgumentParser") as mock:
         suisa_sendemeldung.validate_arguments(mock, args)
         mock.error.assert_called_once_with(
             "\n"
             "- wrong format on bearer_token, expected larger than 32 characters but got 31\n"  # noqa: E501
             "- wrong format on stream_id, expected 9 or 10 characters but got 12\n"
+            "- wrong CRID mode, expected 'cridlib' or 'local'\n"
             "- no output option has been set, specify one of --file, --email or --stdout\n"  # noqa: E501
             "- argument --last_month not allowed with --start_date or --end_date",
         )
@@ -47,6 +49,7 @@ def test_validate_arguments():
             "\n"
             "- wrong format on bearer_token, expected larger than 32 characters but got 31\n"  # noqa: E501
             "- wrong format on stream_id, expected 9 or 10 characters but got 12\n"
+            "- wrong CRID mode, expected 'cridlib' or 'local'\n"
             "- xlsx cannot be printed to stdout, please set --filetype to csv\n"
             "- argument --last_month not allowed with --start_date or --end_date",
         )
@@ -348,6 +351,13 @@ def test_get_csv(mock_cridlib_get, snapshot, args):
             ),
         ],
     )
+
+    # no cridib
+    mock_cridlib_get.reset_mock()
+    args.crid_mode = "local"
+    csv = suisa_sendemeldung.get_csv(data, args=args)
+    assert csv == snapshot
+    mock_cridlib_get.assert_not_called()
 
 
 def test_get_xlsx(snapshot, args):


### PR DESCRIPTION
This makes it possible to generate reports without using cridlib, mainly because cridlib only supports rabe.ch domains for the forseeable future. The alternative output is a based on the same data but simplified to not contain any rabe specific info.