### PR TITLE
feat: specify alternative email templates via file

### DIFF
--- a/suisa_sendemeldung/suisa_sendemeldung.py
+++ b/suisa_sendemeldung/suisa_sendemeldung.py
@@ -259,6 +259,11 @@ def get_arguments(parser: ArgumentParser, sysargs: list[str]) -> ArgparseNamespa
         default=_EMAIL_TEMPLATE,
     )
     parser.add_argument(
+        "--email-text-template-file",
+        env_var="EMAIL_TEXT_TEMPLATE_FILE",
+        help="Specifify a path to an email_text template",
+    )
+    parser.add_argument(
         "--email-footer",
         env_var="EMAIL_FOOTER",
         help="Footer for the Email",
@@ -324,6 +329,9 @@ def get_arguments(parser: ArgumentParser, sysargs: list[str]) -> ArgparseNamespa
     )
     args = parser.parse_args(sysargs)
     validate_arguments(parser, args)  # pragma: no cover
+    if args.email_text_template_file:  # pragma: no cover
+        with Path(args.email_text_template_file).open("r") as template_file:
+            args.email_text = template_file.read()
     return args  # pragma: no cover
 
 

--- a/tests/__snapshots__/test_suisa_sendemeldung.ambr
+++ b/tests/__snapshots__/test_suisa_sendemeldung.ambr
@@ -9,6 +9,7 @@
                 [--email-bcc EMAIL_BCC] [--email-server EMAIL_SERVER]
                 [--email-login EMAIL_LOGIN] [--email-pass EMAIL_PASS]
                 [--email-subject EMAIL_SUBJECT] [--email-text EMAIL_TEXT]
+                [--email-text-template-file EMAIL_TEXT_TEMPLATE_FILE]
                 [--email-footer EMAIL_FOOTER]
                 [--responsible-email RESPONSIBLE_EMAIL]
                 [--start-date START_DATE] [--end-date END_DATE] [--last-month]
@@ -60,6 +61,9 @@
                           $station_name, $month, $year, $previous_year,
                           $responsible_email, and $email_footer. [env var:
                           EMAIL_TEXT]
+    --email-text-template-file EMAIL_TEXT_TEMPLATE_FILE
+                          Specifify a path to an email_text template [env var:
+                          EMAIL_TEXT_TEMPLATE_FILE]
     --email-footer EMAIL_FOOTER
                           Footer for the Email [env var: EMAIL_FOOTER]
     --responsible-email RESPONSIBLE_EMAIL


### PR DESCRIPTION
Our current config format doeesn't allow specifying multiline input in any sane way, so this adds the `--email-text-template-file` option as a workaround.

I considered refactoring the configuration system, but failed to do so without introducing several additional risks.